### PR TITLE
Update the step's Completed flag on the outMessage

### DIFF
--- a/routing-slip/SimpleMessaging/RoutingStep.cs
+++ b/routing-slip/SimpleMessaging/RoutingStep.cs
@@ -52,7 +52,7 @@ namespace SimpleMessaging
                             if (inMessage != null)
                             {
                                 T outMessage = _operation.Execute(inMessage);
-                                inMessage.Steps[inMessage.CurrentStep].Completed = true;
+                                outMessage.Steps[inMessage.CurrentStep].Completed = true;
                                 
                                 int nextStepNo = inMessage.CurrentStep + 1;
                                 if (inMessage.Steps.ContainsKey(nextStepNo))


### PR DESCRIPTION
This fixes the problem that the current step's Completed flag was set on the inMessage which won't become available to the next step.
Need to set the flag on the outMessage so that the next step has correct information that the previous step was completed.
The _operation of course is not supposed to change the CurrentStep, so it's ok to keep using inMessage.CurrentStep for the lookup.