### PR TITLE
fix: use typeof(T).Name instead of nameof(T)

### DIFF
--- a/datatype-channel/SimpleMessaging/DataTypeChannelProducer.cs
+++ b/datatype-channel/SimpleMessaging/DataTypeChannelProducer.cs
@@ -38,7 +38,7 @@ namespace SimpleMessaging
             _channel = _connection.CreateModel();
             
             //Because we are point to point, we are just going to use queueName for the routing key
-            _routingKey = nameof(T);
+            _routingKey = typeof(T).Name;
             //just use the routing key as the queue name; we are still point-to-point
             var queueName = _routingKey;
             


### PR DESCRIPTION
reporting the fix of `typeof()` vs `nameof` in excercies branch