### PR TITLE
Fix Dynamic Naming of routing key

### DIFF
--- a/datatype-channel/SimpleMessaging/DataTypeChannelConsumer.cs
+++ b/datatype-channel/SimpleMessaging/DataTypeChannelConsumer.cs
@@ -38,7 +38,7 @@ namespace SimpleMessaging
              /* We choose to base the key off the type name, because we want tp publish to folks interested in this type
               We name the queue after that routing key as we are point-to-point and only expect one queue to receive
              this type of message */
-            var routingKey = typeof(T);
+            var routingKey = typeof(T).FullName;
             _queueName = routingKey;
             
             _channel.ExchangeDeclare(ExchangeName, ExchangeType.Direct, durable: false);

--- a/datatype-channel/SimpleMessaging/DataTypeChannelConsumer.cs
+++ b/datatype-channel/SimpleMessaging/DataTypeChannelConsumer.cs
@@ -38,7 +38,7 @@ namespace SimpleMessaging
              /* We choose to base the key off the type name, because we want tp publish to folks interested in this type
               We name the queue after that routing key as we are point-to-point and only expect one queue to receive
              this type of message */
-            var routingKey = nameof(T);
+            var routingKey = typeof(T);
             _queueName = routingKey;
             
             _channel.ExchangeDeclare(ExchangeName, ExchangeType.Direct, durable: false);

--- a/datatype-channel/SimpleMessaging/DataTypeChannelProducer.cs
+++ b/datatype-channel/SimpleMessaging/DataTypeChannelProducer.cs
@@ -38,7 +38,7 @@ namespace SimpleMessaging
             _channel = _connection.CreateModel();
             
             //Because we are point to point, we are just going to use queueName for the routing key
-            _routingKey = typeof(T);
+            _routingKey = typeof(T).FullName;
             //just use the routing key as the queue name; we are still point-to-point
             var queueName = _routingKey;
             

--- a/datatype-channel/SimpleMessaging/DataTypeChannelProducer.cs
+++ b/datatype-channel/SimpleMessaging/DataTypeChannelProducer.cs
@@ -38,7 +38,7 @@ namespace SimpleMessaging
             _channel = _connection.CreateModel();
             
             //Because we are point to point, we are just going to use queueName for the routing key
-            _routingKey = nameof(T);
+            _routingKey = typeof(T);
             //just use the routing key as the queue name; we are still point-to-point
             var queueName = _routingKey;
             


### PR DESCRIPTION
`nameof(T)` just gives `T`.