### PR TITLE
Channel with messages with different schemata

### DIFF
--- a/not-datatype-channel/Model/Greeting.cs
+++ b/not-datatype-channel/Model/Greeting.cs
@@ -1,0 +1,9 @@
+﻿using SimpleMessaging;
+
+namespace Model
+{
+    public class Greeting
+    {
+       public string Salutation { get; set; } = "Hello World";
+    }
+}

--- a/not-datatype-channel/Model/Model.csproj
+++ b/not-datatype-channel/Model/Model.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleMessaging\SimpleMessaging.csproj">
+      <Project>{A584491E-5218-463F-AC02-4DA6A932CB16}</Project>
+      <Name>SimpleMessaging</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/not-datatype-channel/Model/Parting.cs
+++ b/not-datatype-channel/Model/Parting.cs
@@ -1,0 +1,9 @@
+﻿using SimpleMessaging;
+
+namespace Model
+{
+    public class Parting
+    {
+       public string Salutation { get; set; } = "Goodbye World";
+    }
+}

--- a/not-datatype-channel/NotDataType-Channel.sln
+++ b/not-datatype-channel/NotDataType-Channel.sln
@@ -1,0 +1,45 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.0.0
+MinimumVisualStudioVersion = 10.0.0.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sender", "Sender/Sender.csproj", "{B8BB6346-E305-4B17-8A81-C976D3610ECF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Receiver", "Receiver\Receiver.csproj", "{6EA744F4-6118-46B5-9578-AC5C64EE346E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleMessaging", "SimpleMessaging\SimpleMessaging.csproj", "{A584491E-5218-463F-AC02-4DA6A932CB16}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{ADC733B4-DADF-44CB-9C7D-3392C1EF4E44}"
+ProjectSection(SolutionItems) = preProject
+	docker-compose.yml = docker-compose.yml
+EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Model", "Model\Model.csproj", "{3254B689-1516-4153-8453-660334CD34EE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B8BB6346-E305-4B17-8A81-C976D3610ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8BB6346-E305-4B17-8A81-C976D3610ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8BB6346-E305-4B17-8A81-C976D3610ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8BB6346-E305-4B17-8A81-C976D3610ECF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EA744F4-6118-46B5-9578-AC5C64EE346E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EA744F4-6118-46B5-9578-AC5C64EE346E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EA744F4-6118-46B5-9578-AC5C64EE346E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EA744F4-6118-46B5-9578-AC5C64EE346E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A584491E-5218-463F-AC02-4DA6A932CB16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A584491E-5218-463F-AC02-4DA6A932CB16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A584491E-5218-463F-AC02-4DA6A932CB16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A584491E-5218-463F-AC02-4DA6A932CB16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3254B689-1516-4153-8453-660334CD34EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3254B689-1516-4153-8453-660334CD34EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3254B689-1516-4153-8453-660334CD34EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3254B689-1516-4153-8453-660334CD34EE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/not-datatype-channel/Receiver/Consumer.cs
+++ b/not-datatype-channel/Receiver/Consumer.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using Model;
+using Newtonsoft.Json;
+using SimpleMessaging;
+
+namespace Sender
+{
+    class Consumer
+    {
+        static void Main(string[] args)
+        {
+            Console.Title = "Practical Messaging: NotDatabype-Challel example (consumer). Press any key to stop.";
+            using (var channel = new NotDataTypeChannelConsumer())
+            {
+                while (!Console.KeyAvailable)
+                {
+                    (object typeHeader, byte[] serialisedMessage) = channel.Receive();
+                    if(typeHeader == null && serialisedMessage == null)
+                    {
+                        Thread.Sleep(1300);
+                        continue;
+                    }
+                    object message = Deserialise(typeHeader, serialisedMessage);
+
+                    if( message as Greeting != null)
+                    {
+                        Console.WriteLine("Greeting: "+ ((Greeting)message).Salutation);
+                    }
+                    else if (message as Parting != null)
+                    {
+                        Console.WriteLine("Parting: " + ((Parting)message).Salutation);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Uknown message type.");
+                    }
+
+                }
+            }
+
+            Console.WriteLine(" Press [enter] to exit.");
+            Console.ReadLine();
+        }
+
+        private static object Deserialise(object type, byte[] message)
+        {
+            string typeString = Encoding.UTF8.GetString((byte[])type);
+            if (typeString == typeof(Greeting).FullName)
+            {
+                return JsonConvert.DeserializeObject<Greeting>(Encoding.UTF8.GetString(message));
+            }
+            else if(typeString == typeof(Parting).FullName)
+            {
+                return JsonConvert.DeserializeObject<Parting>(Encoding.UTF8.GetString(message));
+            }
+            else
+            {
+                Console.WriteLine("Cannot deserialise type {0} becuase it is unknown.", typeString);
+                return null;
+            }
+        }
+    }
+}

--- a/not-datatype-channel/Receiver/Receiver.csproj
+++ b/not-datatype-channel/Receiver/Receiver.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Model\Model.csproj">
+      <Project>{3254B689-1516-4153-8453-660334CD34EE}</Project>
+      <Name>Model</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SimpleMessaging\SimpleMessaging.csproj" />
+  </ItemGroup>
+</Project>

--- a/not-datatype-channel/Sender/Producer.cs
+++ b/not-datatype-channel/Sender/Producer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading;
+using Model;
+using SimpleMessaging;
+
+namespace Sender
+{
+    /// <summary>
+    /// Ina a channel that is not 'data-type' we send messages in multiple different formats, e.g., because they must be processed in sequence.
+    /// </summary>
+    class Producer
+    {
+            class Doodah
+        {
+            public string Salutation { get; set; }
+        }
+
+        static void Main(string[] args)
+        {
+            Console.Title = "Practical Messaging: NotDatabype-Challel example (producer). Press any key to stop.";
+            using (var channel = new NotDataTypeChannelProducer())
+            {
+                object msg = null;
+                bool arrived = false;
+                int n = 1;
+                while (!Console.KeyAvailable)
+                {
+                    int i = n;
+                    if (!arrived)
+                    {
+                        if (DateTime.Now.Millisecond < 359)
+                        {
+                            msg = new Doodah() { Salutation = "BOO! Bet you weren't expecting this: " + n.ToString() };
+                        }
+                        else
+                        {
+                            msg = new Greeting() { Salutation = "Hello " + n.ToString() };
+                            arrived = true;
+                        }
+                    }
+                    else
+                    {
+                        msg = new Parting() { Salutation = "Goodbye " + n.ToString() };
+                        arrived = false;
+                        n++;
+                    }
+
+                    channel.Send(msg);
+                    Console.WriteLine("Sent message {0} of type {1}.", i, msg.GetType().Name);
+                    Thread.Sleep(1300);
+                }
+
+                Console.WriteLine(" Press [enter] to exit.");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/not-datatype-channel/Sender/Sender.csproj
+++ b/not-datatype-channel/Sender/Sender.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Model\Model.csproj">
+      <Project>{3254B689-1516-4153-8453-660334CD34EE}</Project>
+      <Name>Model</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SimpleMessaging\SimpleMessaging.csproj" />
+  </ItemGroup>
+</Project>

--- a/not-datatype-channel/SimpleMessaging/NotDataTypeChannelConsumer.cs
+++ b/not-datatype-channel/SimpleMessaging/NotDataTypeChannelConsumer.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Text;
+using RabbitMQ.Client;
+
+namespace SimpleMessaging
+{
+    public class NotDataTypeChannelConsumer : IDisposable
+    {
+        private const string _routingKey = "practical-messaging-not-datatype";
+        private const string _queueName = "practical-messaging-not-datatype-consumer";
+        private const string ExchangeName = "practical-messaging";
+        private readonly IConnection _connection;
+        private readonly IModel _channel;
+        private bool disposedValue;
+
+        /// <summary>
+        /// Create a new channel for sending point-to-point messages
+        /// Under RMQ we:
+        ///     1. Create a socket connection to the broker
+        ///     2. Create a channel on that socket
+        ///     3. Create a direct exchange on the server for point-to-point messaging 
+        ///     4. Create a queue to hold messages
+        ///     5. Bind the queue to listen to a routing key on that exchange
+        /// We are disposable so that we can be used within a using statement; connections
+        /// are unmanaged resources and we want to remember to close them.
+        /// We are following an RAI pattern here: Resource Acquisition is Initialization
+        /// </summary>
+        /// <param name="messageDeserializer">Takes the message body and turns it into an instance of type T</param>
+        /// <param name="hostName"></param>
+        public NotDataTypeChannelConsumer(string hostName = "localhost")
+        {
+            //just use defaults: usr: guest pwd: guest port:5672 virtual host: /
+            var factory = new ConnectionFactory() { HostName = hostName };
+            factory.AutomaticRecoveryEnabled = true;
+            _connection = factory.CreateConnection();
+            _channel = _connection.CreateModel();
+                        
+            _channel.ExchangeDeclare(ExchangeName, ExchangeType.Direct, durable: false);
+            _channel.QueueDeclare(queue: _queueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
+            _channel.QueueBind(queue:_queueName, exchange: ExchangeName, routingKey: _routingKey);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Receive and ack a message from the queue if one is available, else return null.
+        /// </para>
+        /// <para>
+        /// Deserialising is done in here which creates a dependency on the model -- this class is probably doing too much!
+        /// </para>
+        /// <para>
+        /// The queue should have received all message published because we create it in the constructor, so the
+        /// producer will create as well as the consumer making the ordering unimportant.
+        /// </para>
+        /// </summary>
+        /// <returns>The message type string (C# clas full name), and the (serialised) message body.</returns>
+        public (object, byte[]) Receive()
+        {
+            BasicGetResult result = _channel.BasicGet(_queueName, autoAck: true);
+            if (result != null)
+            {
+                object type = null;
+                bool gotType = false;
+                if (result.BasicProperties != null && result.BasicProperties.Headers != null)
+                {
+                    gotType = result.BasicProperties.Headers.TryGetValue("x-message-type", out type);
+                }
+
+                if( !gotType)
+                {
+                    string foo = Encoding.UTF8.GetString(result.Body);
+                    return (null, null);
+                }
+
+                // We can't deserialise the message here because we don't depend on the Model dll.
+                // We could inject a deserialisation service, as in the other examples, but for simplicity we leave it for the caller to deal with.
+
+                return (type, result.Body);
+            }
+            else
+            {
+                return (null, null);
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _channel.Close();
+                    _channel.Dispose();
+
+                    _connection.Close();
+                    _connection.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~NotDataTypeChannelProducer()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        void IDisposable.Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/not-datatype-channel/SimpleMessaging/NotDataTypeChannelProducer.cs
+++ b/not-datatype-channel/SimpleMessaging/NotDataTypeChannelProducer.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using RabbitMQ.Client;
+
+namespace SimpleMessaging
+{
+    public class NotDataTypeChannelProducer : IDisposable
+    {
+        private const string _routingKey = "practical-messaging-not-datatype";
+        private const string ExchangeName = "practical-messaging";
+        private readonly IConnection _connection;
+        private readonly IModel _channel;
+        private bool disposedValue;
+
+        /// <summary>
+        /// Create a new channel for sending point-to-point messages.
+        /// Under RMQ we:
+        ///     1. Create a socket connection to the broker
+        ///     2. Create a channel on that socket
+        ///     3. Create a direct exchange on the server for point-to-point messaging
+        /// We don't create the receiving queue - each consumer does that, and will route to our
+        /// key.
+        /// We have split producer and consumer, as they need seperate serialization/de-serialization of the message
+        /// We are disposable so that we can be used within a using statement; connections
+        /// are unmanaged resources and we want to remember to close them.
+        /// We inject the serializer to use with this type, so we can read and write the type to the body
+        /// We are following an RAI pattern here: Resource Acquisition is Initialization
+        /// </summary>
+        /// <param name="messageSerializer">Needs to take a message of type T and convert to a string</param>
+        /// <param name="hostName">localhost if not otherwise specified</param>
+        public NotDataTypeChannelProducer(string hostName = "localhost")
+        {
+            //just use defaults: usr: guest pwd: guest port:5672 virtual host: /
+            var factory = new ConnectionFactory() { HostName = hostName };
+            factory.AutomaticRecoveryEnabled = true;
+            _connection = factory.CreateConnection();
+            _channel = _connection.CreateModel();
+            
+            // Because we are point to point, we are just going to use queueName for the routing key
+            // just use the routing key as the queue name; we are still point-to-point.
+
+            // We could make this even more exciting by using an exchange of type Headers
+            // which would send the message to different output queues depending by inspecting the message headers.
+
+            var queueName = _routingKey;
+            
+            _channel.ExchangeDeclare(ExchangeName, ExchangeType.Direct, durable: false);
+            _channel.QueueDeclare(queue: queueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
+            _channel.QueueBind(queue:queueName, exchange: ExchangeName, routingKey: _routingKey);
+     }
+
+        /// <summary>
+        /// <para>
+        /// Send a message over the channel.
+        /// Uses the shared routing key to ensure the sender and receiver match up.
+        /// </para>
+        /// <para>
+        /// IMPORTANT! For this non-dataype channel we add a header to describe the message format (it is just the C# type name -- which may mean that the producer and consumer are 'bound' by a mutual dependency on this type).
+        /// </para>
+        /// </summary>
+        /// <param name="message"></param>
+        public void Send(object message)
+        {
+            var body = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message));
+            IBasicProperties basicProperties = _channel.CreateBasicProperties();
+            basicProperties.Headers = new Dictionary<string, object>();
+            basicProperties.Headers.Add("x-message-type", message.GetType().FullName);
+            _channel.BasicPublish(exchange: ExchangeName, routingKey: _routingKey, basicProperties: basicProperties, body: body);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _channel.Close();
+                    _channel.Dispose();
+
+                    _connection.Close();
+                    _connection.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~NotDataTypeChannelProducer()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        void IDisposable.Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/not-datatype-channel/SimpleMessaging/SimpleMessaging.csproj
+++ b/not-datatype-channel/SimpleMessaging/SimpleMessaging.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+  </ItemGroup>
+</Project>

--- a/not-datatype-channel/docker-compose.yml
+++ b/not-datatype-channel/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    restart: on-failure
+    volumes:
+      - rabbitmq-home:/var/lib/rabbitmq
+    restart: on-failure
+
+volumes:
+  rabbitmq-home:
+    driver: local


### PR DESCRIPTION
The `datatype-channel` example shows a point-to-point channel/exchange/queue (whatever it is) with messages all in the same known format. It is more interesting to use the same single channel(whatever) to send messages that are of different formats. This example shows how this could be done; the sender adds a custom header that decribes the message format and the receiver uses this to dispatch the message to the appropriate handler.